### PR TITLE
Map Cypress status to TestRail status and allow status mapping override

### DIFF
--- a/src/get-config.js
+++ b/src/get-config.js
@@ -12,6 +12,14 @@ function hasConfig(env = process.env) {
   )
 }
 
+function safelyParseJson(str) {
+  try {
+      return JSON.parse(str)
+  } catch (e) {
+      return {}
+  }
+}
+
 function getTestRailConfig(env = process.env) {
   const debug = require('debug')('cypress-testrail-simple')
 
@@ -34,6 +42,7 @@ function getTestRailConfig(env = process.env) {
     password: process.env.TESTRAIL_PASSWORD,
     projectId: process.env.TESTRAIL_PROJECTID,
     suiteId: process.env.TESTRAIL_SUITEID,
+    statusOverride: safelyParseJson(process.env.TESTRAIL_STATUS_OVERRIDE),
   }
   debug('test rail info with the password masked')
   debug('%o', { ...testRailInfo, password: '<masked>' })


### PR DESCRIPTION
Map all Cypress test states into TestRail status

| Cypress status | TestRail Status | TestRail Status ID |
| -------------- | --------------- | ------------------ |
| Passed         | Passed          | 1                  |
| N/A            | Blocked         | 2                  |
| Pending        | Untested        | 3                  |
| Skipped        | Retest          | 4                  |
| Failed         | Failed          | 5                  |

Above default status mapping can be also overwritten by setting `TESTRAIL_STATUS_OVERRIDE` in environment variable. Make sure to stringify the object using `JSON.stringify()` so that it can be parsed from the plugin. 
```
{
  "env": {
    "TESTRAIL_STATUS_OVERRIDE": {
      "skipped": 6
    }
  }
}
```