### PR TITLE
feat: refactor to use find-test-names module

### DIFF
--- a/bin/testrail-start-run.js
+++ b/bin/testrail-start-run.js
@@ -20,6 +20,8 @@ const args = arg(
     // find the specs automatically using
     // https://github.com/bahmutov/find-cypress-specs
     '--find-specs': Boolean,
+    // do not open the test run, just find everything
+    '--dry': Boolean,
     // aliases
     '-s': '--spec',
     '-n': '--name',
@@ -119,8 +121,12 @@ if (args['--find-specs']) {
   const caseIds = findCases(specs)
   debug('found %d TestRail case ids: %o', caseIds.length, caseIds)
 
-  const testRailInfo = getTestRailConfig()
-  startRun({ testRailInfo, name, description, caseIds })
+  if (args['--dry']) {
+    console.log('Dry run, not starting a new run')
+  } else {
+    const testRailInfo = getTestRailConfig()
+    startRun({ testRailInfo, name, description, caseIds })
+  }
 } else if (args['--spec']) {
   findSpecs(args['--spec']).then((specs) => {
     debug('using pattern "%s" found specs', args['--spec'])

--- a/cypress/integration/find-cases-spec.js
+++ b/cypress/integration/find-cases-spec.js
@@ -26,8 +26,8 @@ describe('Finding test case IDs', () => {
     `
     const readFile = cy.stub().returns(source)
     const filename = 'test-spec.js'
-    const ids = findCasesInSpec(filename, readFile)
-    expect(ids, 'test cases').to.deep.equal([1, 2002, 199, 123, 456])
+    const ids = findCasesInSpec(filename, readFile).sort()
+    expect(ids, 'test cases').to.deep.equal([1, 123, 199, 2002, 456])
     expect(readFile).to.be.calledOnceWithExactly(filename, 'utf8')
   })
 
@@ -61,7 +61,10 @@ describe('Finding test case IDs', () => {
     readFile.withArgs('file2.js', 'utf8').returns(source2)
     readFile.withArgs('file3.js', 'utf8').returns(source3)
     readFile.withArgs('file4.js', 'utf8').returns(source4)
-    const ids = findCases(['file1.js', 'file2.js', 'file3.js', 'file4.js'], readFile)
+    const ids = findCases(
+      ['file1.js', 'file2.js', 'file3.js', 'file4.js'],
+      readFile,
+    )
     expect(ids, 'test cases').to.deep.equal([1, 199, 123])
   })
 
@@ -88,9 +91,13 @@ describe('Finding test case IDs', () => {
 
   it('can be in different quotes', () => {
     const source = `
-      "C1"
-      'C2'
-      \`C3\`
+      it("C1")
+
+      it('C2', () => {})
+
+      it(\`C3\`, () => {
+        // works
+      })
     `
     const readFile = cy.stub().returns(source)
     const filename = 'test-spec.js'

--- a/cypress/integration/spec-a.js
+++ b/cypress/integration/spec-a.js
@@ -5,7 +5,7 @@ describe('parent', () => {
   // both used to group similar tests together
   context('inner', () => {
     // test rail case ID "1"
-    it('C1 works', () => {
+    it('C1 works', { tags: '@real' }, () => {
       cy.wait(15000)
     })
   })

--- a/cypress/integration/spec-b.js
+++ b/cypress/integration/spec-b.js
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-describe('parent2', () => {
+describe('parent2', { tags: '@real' }, () => {
   // "context" is just an alias to "describe"
   // both used to group similar tests together
   context('inner2', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "arg": "^5.0.1",
         "debug": "^4.3.2",
         "find-cypress-specs": "^1.17.0",
+        "find-test-names": "^1.15.1",
         "globby": "^11",
         "got": "^11.8.2"
       },

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "arg": "^5.0.1",
     "debug": "^4.3.2",
     "find-cypress-specs": "^1.17.0",
+    "find-test-names": "^1.15.1",
     "globby": "^11",
     "got": "^11.8.2"
   },


### PR DESCRIPTION
Should be just under the hood change, but want to have a separate release for debugging purpose