### PR TITLE
feat: support multiple test case IDs

### DIFF
--- a/.github/workflows/multiple-cases.yml
+++ b/.github/workflows/multiple-cases.yml
@@ -1,0 +1,64 @@
+# starts a new TestRail run but with test cases from some specs only
+# the test title has multiple test case IDs
+name: multiple cases
+on: [push]
+jobs:
+  tests:
+    runs-on: ubuntu-20.04
+    env:
+      # pass TestRail settings from the project secrets
+      # via environment variables
+      TESTRAIL_HOST: ${{secrets.TESTRAIL_HOST}}
+      TESTRAIL_USERNAME: ${{secrets.TESTRAIL_USERNAME}}
+      TESTRAIL_PASSWORD: ${{secrets.TESTRAIL_PASSWORD}}
+      # the project ID is not that secret
+      TESTRAIL_PROJECTID: 1
+      # for debugging the scripts in this package
+      DEBUG: cypress-testrail-simple
+
+    steps:
+      - name: Checkout 🛎
+        uses: actions/checkout@v2
+
+      # Install NPM dependencies, cache them correctly
+      - name: Install 📦
+        uses: cypress-io/github-action@v4
+        with:
+          runTests: false
+
+      # you can pass GitHub information in the name and description
+      # to include in the TestRail run information
+      # https://docs.github.com/en/actions/learn-github-actions/contexts
+      - name: Start TestRail Run 🏃🏻‍♂️
+        id: testRail
+        run: |
+          runName="Testing multiple test cases in the title"
+          runDescription="Cypress tests for commit ${GITHUB_SHA} ${GITHUB_REF}"
+
+          echo ${runName}
+          echo ${runDescription}
+
+          runId=$(node ./bin/testrail-start-run.js \
+            --spec 'cypress/integration/spec-c.js' \
+            --name "${runName}" \
+            --description "${runDescription}")
+          echo "TestRail run id ${runId}"
+          # save the run ID as the output from this step
+          echo "::set-output name=runId::${runId}"
+
+      - name: Cypress tests 🧪
+        uses: cypress-io/github-action@v4
+        with:
+          install-command: echo "Already installed"
+          record: true
+          group: Cases GitHub Actions
+          spec: 'cypress/integration/spec-c.js'
+        env:
+          TESTRAIL_RUN_ID: ${{ steps.testRail.outputs.runId }}
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+
+      - name: Close TestRail Run 🏁
+        # always close the test run, even if the previous steps have failed
+        if: ${{ always() }}
+        run: |
+          node ./bin/testrail-close-run.js ${{ steps.testRail.outputs.runId }}

--- a/cypress/integration/find-case-ids-spec.js
+++ b/cypress/integration/find-case-ids-spec.js
@@ -3,10 +3,24 @@ import { getTestCases } from '../../src/find-cases'
 
 describe('getTestCases', () => {
   it('returns an undefined without test cases in the title', () => {
-    expect(getTestCases('hello world')).to.equal(undefined)
+    expect(getTestCases('hello world')).to.deep.equal([])
   })
 
   it('returns a single number', () => {
-    expect(getTestCases('hello C101 world')).to.equal(101)
+    expect(getTestCases('hello C101 world')).to.deep.equal([101])
+  })
+
+  it('finds several test case IDs', () => {
+    expect(getTestCases('hello C101 world C202')).to.deep.equal([101, 202])
+  })
+
+  it('finds case IDs at the start and the end', () => {
+    expect(getTestCases('C101 hello world C202')).to.deep.equal([101, 202])
+  })
+
+  it('removes duplicates', () => {
+    expect(getTestCases('C101 hello C101 world C202 C202')).to.deep.equal([
+      101, 202,
+    ])
   })
 })

--- a/cypress/integration/find-cases-spec.js
+++ b/cypress/integration/find-cases-spec.js
@@ -104,4 +104,30 @@ describe('Finding test case IDs', () => {
     const ids = findCasesInSpec(filename, readFile)
     expect(ids, 'test cases').to.deep.equal([1, 2, 3])
   })
+
+  it('supports multiple test cases per title', () => {
+    const source = `
+      it('C303 works C101 C202', () => {})
+    `
+    const readFile = cy.stub().returns(source)
+    const filename = 'test-spec.js'
+    const ids = findCasesInSpec(filename, readFile)
+    // output is sorted
+    expect(ids, 'test cases').to.deep.equal([101, 202, 303])
+  })
+
+  it('supports multiple test cases', () => {
+    const source = `
+      it('C303 works C101 C202', () => {})
+
+      it('C101 C202 loads', () => {})
+
+      it('C303 completes', () => {})
+    `
+    const readFile = cy.stub().returns(source)
+    const filename = 'test-spec.js'
+    const ids = findCasesInSpec(filename, readFile)
+    // output is sorted
+    expect(ids, 'test cases').to.deep.equal([101, 202, 303])
+  })
 })

--- a/cypress/integration/spec-c.js
+++ b/cypress/integration/spec-c.js
@@ -1,0 +1,6 @@
+/// <reference types="cypress" />
+
+// an example of a single test with multiple test case IDs
+it('C15 C103 works C1', () => {
+  cy.wait(1000)
+})

--- a/src/find-cases.js
+++ b/src/find-cases.js
@@ -6,11 +6,17 @@ const { getTestNames, filterByEffectiveTags } = require('find-test-names')
  * @param {string} testTitle
  */
 function getTestCases(testTitle) {
-  const matches = testTitle.match(/\bC(?<caseId>\d+)\b/)
-  if (!matches) {
-    return
-  }
-  return Number(matches.groups.caseId)
+  const re = /\bC(?<caseId>\d+)\b/g
+  const matches = [...testTitle.matchAll(re)]
+  const ids = matches.map((m) => Number(m.groups.caseId))
+  return uniqueSorted(ids)
+}
+
+/**
+ * Gives an array, removes duplicates and sorts it
+ */
+function uniqueSorted(list) {
+  return Array.from(new Set(list)).sort()
 }
 
 /**
@@ -29,11 +35,13 @@ function findCasesInSpec(spec, readSpec = fs.readFileSync, tagged) {
     testNames = found.testNames
   }
 
-  // a single test case ID per test title for now
-  const ids = testNames.map(getTestCases).filter((id) => !isNaN(id))
+  const ids = testNames
+    .map(getTestCases)
+    .reduce((a, b) => a.concat(b), [])
+    .filter((id) => !isNaN(id))
 
   // make sure the test ids are unique
-  return Array.from(new Set(ids)).sort()
+  return uniqueSorted(ids)
 }
 
 function findCases(specs, readSpec = fs.readFileSync, tagged) {


### PR DESCRIPTION
A single test name might have multiple test cases

```js
it('C303 works C101 C202', () => {})
```

- closes #28