### PR TITLE
Don't parse results.test when attribute not present

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -83,51 +83,54 @@ async function registerPlugin(on, config, skipPlugin = false) {
 
     // find only the tests with TestRail case id in the test name
     const testRailResults = []
-    results.tests.forEach((result) => {
-      /**
-       *  Cypress to TestRail Status Mapping
-       *
-       *  | Cypress status | TestRail Status | TestRail Status ID |
-       *  | -------------- | --------------- | ------------------ |
-       *  | created        | Untested        | 3                  |
-       *  | Passed         | Passed          | 1                  |
-       *  | Pending        | Blocked         | 2                  |
-       *  | Skipped        | Retest          | 4                  |
-       *  | Failed         | Failed          | 5                  |
-       *
-       *  Each test starts as "Untested" in TestRail.
-       *  @see https://glebbahmutov.com/blog/cypress-test-statuses/
-       */
-      const defaultStatus = {
-        passed: 1,
-        pending: 2,
-        skipped: 4,
-        failed: 5,
-      }
-      // override status mapping if defined by user
-      const statusOverride = testRailInfo.statusOverride
-      const status = {
-        ...defaultStatus,
-        ...statusOverride,
-      }
-      // only look at the test name, not at the suite titles
-      const testName = result.title[result.title.length - 1]
-      // there might be multiple test case IDs per test title
-      const testCaseIds = getTestCases(testName)
-      testCaseIds.forEach((case_id) => {
-        const status_id = status[result.state] || defaultStatus.failed
-        const testRailResult = {
-          case_id,
-          status_id,
+    if (results.tests) {
+      results.tests.forEach((result) => {
+        /**
+         *  Cypress to TestRail Status Mapping
+         *
+         *  | Cypress status | TestRail Status | TestRail Status ID |
+         *  | -------------- | --------------- | ------------------ |
+         *  | created        | Untested        | 3                  |
+         *  | Passed         | Passed          | 1                  |
+         *  | Pending        | Blocked         | 2                  |
+         *  | Skipped        | Retest          | 4                  |
+         *  | Failed         | Failed          | 5                  |
+         *
+         *  Each test starts as "Untested" in TestRail.
+         *  @see https://glebbahmutov.com/blog/cypress-test-statuses/
+         */
+        const defaultStatus = {
+          passed: 1,
+          pending: 2,
+          skipped: 4,
+          failed: 5,
         }
-
-        if (caseIds.length && !caseIds.includes(case_id)) {
-          debug('case %d is not in test run %d', case_id, runId)
-        } else {
-          testRailResults.push(testRailResult)
+        // override status mapping if defined by user
+        const statusOverride = testRailInfo.statusOverride
+        const status = {
+          ...defaultStatus,
+          ...statusOverride,
         }
+        // only look at the test name, not at the suite titles
+        const testName = result.title[result.title.length - 1]
+        // there might be multiple test case IDs per test title
+        const testCaseIds = getTestCases(testName)
+        testCaseIds.forEach((case_id) => {
+          const status_id = status[result.state] || defaultStatus.failed
+          const testRailResult = {
+            case_id,
+            status_id,
+          }
+  
+          if (caseIds.length && !caseIds.includes(case_id)) {
+            debug('case %d is not in test run %d', case_id, runId)
+          } else {
+            testRailResults.push(testRailResult)
+          }
+        })
       })
-    })
+    }
+    
     if (testRailResults.length) {
       console.log('TestRail results in %s', spec.relative)
       console.table(testRailResults)


### PR DESCRIPTION
This is a fix for the error that appears during a chrome renderer crash...
```
We detected that the Chromium Renderer process just crashed.

This is the equivalent to seeing the 'sad face' when Chrome dies.

This can happen for a number of different reasons:

- You wrote an endless loop and you must fix your own code
- You are running Docker (there is an easy fix for this: see link below)
- You are running lots of tests on a memory intense application.
    - Try enabling experimentalMemoryManagement in your config file.
    - Try lowering numTestsKeptInMemory in your config file.
- You are running in a memory starved VM environment.
    - Try enabling experimentalMemoryManagement in your config file.
    - Try lowering numTestsKeptInMemory in your config file.
- There are problems with your GPU / GPU drivers
- There are browser bugs in Chromium

You can learn more including how to fix Docker here:

https://on.cypress.io/renderer-process-crashed
An error was thrown in your plugins file while executing the handler for the after:spec event.

The error we received was:

TypeError: Cannot read properties of null (reading 'forEach')
    at Object.handler (/home/circleci/project/node_modules/cypress-testrail-simple/src/plugin.js:86:19)
    at invoke (/home/circleci/.cache/Cypress/12.5.1/Cypress/resources/app/node_modules/@packages/server/lib/plugins/child/run_plugins.js:43:18)
    at /home/circleci/.cache/Cypress/12.5.1/Cypress/resources/app/node_modules/@packages/server/lib/plugins/util.js:59:14
    at tryCatcher (/home/circleci/.cache/Cypress/12.5.1/Cypress/resources/app/node_modules/bluebird/js/release/util.js:16:23)
    at Function.Promise.attempt.Promise.try (/home/circleci/.cache/Cypress/12.5.1/Cypress/resources/app/node_modules/bluebird/js/release/method.js:39:29)
    at Object.wrapChildPromise (/home/circleci/.cache/Cypress/12.5.1/Cypress/resources/app/node_modules/@packages/server/lib/plugins/util.js:58:23)
    at RunPlugins.execute (/home/circleci/.cache/Cypress/12.5.1/Cypress/resources/app/node_modules/@packages/server/lib/plugins/child/run_plugins.js:180:21)
    at EventEmitter.<anonymous> (/home/circleci/.cache/Cypress/12.5.1/Cypress/resources/app/node_modules/@packages/server/lib/plugins/child/run_plugins.js:279:12)
    at EventEmitter.emit (node:events:514:28)
    at EventEmitter.emit (node:domain:489:12)
    at process.<anonymous> (/home/circleci/.cache/Cypress/12.5.1/Cypress/resources/app/node_modules/@packages/server/lib/plugins/util.js:33:22)
    at process.emit (node:events:514:28)
    at process.emit (node:domain:489:12)
    at process.emit.sharedData.processEmitHook.installedValue [as emit] (/home/circleci/.cache/Cypress/12.5.1/Cypress/resources/app/node_modules/@cspotcode/source-map-support/source-map-support.js:745:40)
    at emit (node:internal/child_process:937:14)
    at processTicksAndRejections (node:internal/process/task_queues:83:21)
```